### PR TITLE
Package was not really supported in Laravel 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 5.6.1 - 2018-02-12
+- Updated `graham-campbell/manager` to support Laravel 5.6
+- Updated PHPDoc to reflect new HA-IP methods in `hiddeco/transip`
+
 ## 5.6 - 2018-02-10
 - Added Laravel 5.6 support
 - `hiddeco/transip` version update `v5.5` -> `v5.6`

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
   "require": {
     "illuminate/contracts": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
     "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-    "graham-campbell/manager": "~3.0",
+    "graham-campbell/manager": "~3.0|~4.0",
     "hiddeco/transip": "~5.6"
   },
   "require-dev": {
-    "graham-campbell/testbench": "~3.0",
+    "graham-campbell/testbench": "~3.0|~4.0|~5.0",
     "mockery/mockery": "0.9.*",
     "phpunit/phpunit": "4.*"
   },

--- a/src/TransIPFactory.php
+++ b/src/TransIPFactory.php
@@ -23,7 +23,7 @@ class TransIPFactory
      *
      * @param array $config
      *
-     * @return \HiddeCo\TransIP\Client
+     * @return \TransIP\Client
      */
     public function create(array $config)
     {

--- a/src/TransIPManager.php
+++ b/src/TransIPManager.php
@@ -32,6 +32,11 @@ use Illuminate\Contracts\Config\Repository;
  * @method \TransIP\Api\WebHosting webHosting()
  * @method \TransIP\Api\WebHosting web_hosting_service()
  * @method \TransIP\Api\WebHosting webHostingService()
+ * @method \TransIP\Api\Haip       haip()
+ * @method \TransIP\Api\Haip       ha_ip()
+ * @method \TransIP\Api\Haip       ha_ip_service()
+ * @method \TransIP\Api\Haip       haip_service()
+ * @method \TransIP\Api\Haip       haipService()
  *
  * @author Hidde Beydals <hello@hidde.co>
  */
@@ -61,7 +66,7 @@ class TransIPManager extends AbstractManager
      *
      * @param array $config
      *
-     * @return \HiddeCo\TransIP\Client
+     * @return \TransIP\Client
      */
     protected function createConnection(array $config)
     {


### PR DESCRIPTION
I didn't notice the `graham-campbell/manager` dependency, I've now tested this with a fresh L5.6 installation and `laravel-transip` installs fine now 😄 